### PR TITLE
chore: update sonarcloud version and docker tag to frontliners

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.2.0] - 2024-02-21
+
+- Updated `SonarCloud` version
+- Partially renamed `Inforit` with `Frontliners` for docker and strings with no technical impact
+
 ## [3.1.0] - 2023-03-31
 
 - Changed to normal node buster image instead of slim variant

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,9 +17,9 @@ RUN apt-get update && \
   rm -rf /var/lib/apt/lists/*
 
 # install sonar-scanner
-ENV SONAR_VERSION="4.6.2.2472-linux"
-COPY sonar-scanner-cli-$SONAR_VERSION.zip /var/opt/
-RUN unzip /var/opt/sonar-scanner-cli-$SONAR_VERSION.zip -d /var/opt && \
+ENV SONAR_VERSION="5.0.1.3006-linux"
+RUN curl https://binaries.sonarsource.com/Distribution/sonar-scanner-cli/sonar-scanner-cli-$SONAR_VERSION.zip -o /var/opt/sonar-scanner-cli-$SONAR_VERSION.zip && \
+  unzip /var/opt/sonar-scanner-cli-$SONAR_VERSION.zip -d /var/opt && \
   rm /var/opt/sonar-scanner-cli-$SONAR_VERSION.zip
 ENV PATH="$PATH:/var/opt/sonar-scanner-$SONAR_VERSION/bin"
 

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2021 INFORIT
+Copyright (c) 2021 FRONTLINERS
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # bitbucket-pipelines front-end-build
 
-[![logo](./logo.jpg)](https://inforit.nl)
+[![logo](./logo.jpg)](https://frontliners.nl)
 
 Docker image to automate front-end builds on bitbucket (and local)
 
@@ -31,7 +31,7 @@ Also sonar-scanner is installed to enable sonar analyzing
 ## Usage
 
 ```sh
-image: inforitnl/front-end-build
+image: frontliners/front-end-build
 
 pipelines:
   default:

--- a/package.json
+++ b/package.json
@@ -1,22 +1,22 @@
 {
   "name": "front-end-build",
-  "version": "3.1.0",
-  "description": "[![logo](./logo.jpg)](https://inforit.nl)",
+  "version": "3.2.0",
+  "description": "[![logo](./logo.jpg)](https://frontliners.nl)",
   "main": "index.js",
   "scripts": {
-    "build": "docker build -t inforitnl/front-end-build .",
-    "tag": "docker tag inforitnl/front-end-build",
-    "push": "docker push inforitnl/front-end-build",
-    "publish": "DOCKER_PROD_TAG=$(cat package.json | grep version | head -1  | awk -F: '{ print $2}' | sed 's/[\",]//g' | tr -d '[[:space:]]') && docker build -t inforitnl/front-end-build . && docker tag inforitnl/front-end-build inforitnl/front-end-build:latest && docker tag inforitnl/front-end-build inforitnl/front-end-build:$DOCKER_PROD_TAG  && docker push inforitnl/front-end-build:latest && docker push inforitnl/front-end-build:$DOCKER_PROD_TAG "
+    "build": "docker build -t frontliners/front-end-build .",
+    "tag": "docker tag frontliners/front-end-build",
+    "push": "docker push frontliners/front-end-build",
+    "publish": "DOCKER_PROD_TAG=$(cat package.json | grep version | head -1  | awk -F: '{ print $2}' | sed 's/[\",]//g' | tr -d '[[:space:]]') && docker build -t frontliners/front-end-build . && docker tag frontliners/front-end-build frontliners/front-end-build:latest && docker tag frontliners/front-end-build frontliners/front-end-build:$DOCKER_PROD_TAG  && docker push frontliners/front-end-build:latest && docker push frontliners/front-end-build:$DOCKER_PROD_TAG "
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/Inforitnl/front-end-build.git"
+    "url": "git+https://github.com/frontlinersnl/front-end-build.git"
   },
   "author": "Rick van Lieshout <info@rickvanlieshout.com> (http://rickvanlieshout.com)",
   "license": "ISC",
   "bugs": {
-    "url": "https://github.com/Inforitnl/front-end-build/issues"
+    "url": "https://github.com/frontlinersnl/front-end-build/issues"
   },
-  "homepage": "https://github.com/Inforitnl/front-end-build#readme"
+  "homepage": "https://github.com/frontlinersnl/front-end-build#readme"
 }


### PR DESCRIPTION
### Purpose

The purpose of this PR is to create a docker image which behaves just like 3.1.0 but with an updated Sonarcloud version required for the pipeline. For ShuntPlan, 4.0.0 cannot be used due to issues/risks posed by updating to node 20.x.x